### PR TITLE
DENG-215: pin dependency versions (.yarnrc)

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix ""

--- a/package.json
+++ b/package.json
@@ -10,16 +10,16 @@
   ],
   "description": "Fender Design System",
   "devDependencies": {
-    "css-loader": "^3.4.2",
-    "css-mqpacker": "^7.0.0",
-    "cssnano": "^4.1.10",
-    "perfectionist": "^2.4.0",
-    "postcss-cli": "^7.1.0",
-    "postcss-conditionals": "^2.1.0",
-    "postcss-cssnext": "^3.1.0",
-    "postcss-discard-comments": "^4.0.2",
-    "postcss-import": "^12.0.1",
-    "prettier": "^2.0.2"
+    "css-loader": "3.4.2",
+    "css-mqpacker": "7.0.0",
+    "cssnano": "4.1.10",
+    "perfectionist": "2.4.0",
+    "postcss-cli": "7.1.0",
+    "postcss-conditionals": "2.1.0",
+    "postcss-cssnext": "3.1.0",
+    "postcss-discard-comments": "4.0.2",
+    "postcss-import": "12.0.1",
+    "prettier": "2.0.2"
   },
   "files": [
     "css",

--- a/yarn.lock
+++ b/yarn.lock
@@ -457,7 +457,7 @@ css-declaration-sorter@^4.0.1:
     postcss "^7.0.1"
     timsort "^0.3.0"
 
-css-loader@^3.4.2:
+css-loader@^3.4.2, "css-loader@3.4.2":
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.4.2.tgz#d3fdb3358b43f233b78501c5ed7b1c6da6133202"
   integrity sha512-jYq4zdZT0oS0Iykt+fqnzVLRIeiPWhka+7BqPn+oSIpWJAHak5tmB/WZrJ2a21JhCeFyNnnlroSl8c+MtVndzA==
@@ -475,7 +475,7 @@ css-loader@^3.4.2:
     postcss-value-parser "^4.0.2"
     schema-utils "^2.6.0"
 
-css-mqpacker@^7.0.0:
+css-mqpacker@^7.0.0, "css-mqpacker@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/css-mqpacker/-/css-mqpacker-7.0.0.tgz#48f4a0ff45b81ec661c4a33ed80b9db8a026333b"
   integrity sha512-temVrWS+sB4uocE2quhW8ru/KguDmGhCU7zN213KxtDvWOH3WS/ZUStfpF4fdCT7W8fPpFrQdWRFqtFtPPfBLA==
@@ -586,7 +586,7 @@ cssnano-util-same-parent@^4.0.0:
   resolved "https://registry.yarnpkg.com/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz#574082fb2859d2db433855835d9a8456ea18bbf3"
   integrity sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==
 
-cssnano@^4.1.10:
+cssnano@^4.1.10, "cssnano@4.1.10":
   version "4.1.10"
   resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-4.1.10.tgz#0ac41f0b13d13d465487e111b778d42da631b8b2"
   integrity sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==
@@ -1367,7 +1367,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-perfectionist@^2.4.0:
+perfectionist@^2.4.0, "perfectionist@2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/perfectionist/-/perfectionist-2.4.0.tgz#c147ad3714e126467f1764129ee72df861d47ea0"
   integrity sha1-wUetNxThJkZ/F2QSnuct+GHUfqA=
@@ -1447,7 +1447,7 @@ postcss-calc@^7.0.1:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.0.2"
 
-postcss-cli@^7.1.0:
+postcss-cli@^7.1.0, "postcss-cli@7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/postcss-cli/-/postcss-cli-7.1.0.tgz#769b07b8865aaa3e98c7c63a3d256b4f51e3e237"
   integrity sha512-tCGK0GO2reu644dUHxks8U2SAtKnzftQTAXN1dwzFPoKXZr0b7VX4vTkQ2Pl2Lunas6+o8uHR56hlcYBm1srZg==
@@ -1541,7 +1541,7 @@ postcss-colormin@^4.0.3:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
-postcss-conditionals@^2.1.0:
+postcss-conditionals@^2.1.0, "postcss-conditionals@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/postcss-conditionals/-/postcss-conditionals-2.1.0.tgz#4d1f62aa540458ce7ab779f71656901c8f8e929a"
   integrity sha1-TR9iqlQEWM56t3n3FlaQHI+Okpo=
@@ -1558,7 +1558,7 @@ postcss-convert-values@^4.0.1:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
-postcss-cssnext@^3.1.0:
+postcss-cssnext@^3.1.0, "postcss-cssnext@3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/postcss-cssnext/-/postcss-cssnext-3.1.0.tgz#927dc29341a938254cde38ea60a923b9dfedead9"
   integrity sha512-awPDhI4OKetcHCr560iVCoDuP6e/vn0r6EAqdWPpAavJMvkBSZ6kDpSN4b3mB3Ti57hQMunHHM8Wvx9PeuYXtA==
@@ -1615,7 +1615,7 @@ postcss-custom-selectors@^4.0.1:
     postcss "^6.0.1"
     postcss-selector-matches "^3.0.0"
 
-postcss-discard-comments@^4.0.2:
+postcss-discard-comments@^4.0.2, "postcss-discard-comments@4.0.2":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz#1fbabd2c246bff6aaad7997b2b0918f4d7af4033"
   integrity sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==
@@ -1663,7 +1663,7 @@ postcss-image-set-polyfill@^0.3.5:
     postcss "^6.0.1"
     postcss-media-query-parser "^0.2.3"
 
-postcss-import@^12.0.1:
+postcss-import@^12.0.1, "postcss-import@12.0.1":
   version "12.0.1"
   resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-12.0.1.tgz#cf8c7ab0b5ccab5649024536e565f841928b7153"
   integrity sha512-3Gti33dmCjyKBgimqGxL3vcV8w9+bsHwO5UrBawp796+jdardbcFl4RP5w/76BwNL7aGzpKstIfF9I+kdE8pTw==
@@ -2056,7 +2056,7 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.2
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-prettier@^2.0.2:
+prettier@^2.0.2, "prettier@2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
   integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==


### PR DESCRIPTION
## DENG-215 — dependency supply-chain hardening (Tier 1: config)

This PR adds `.yarnrc` to enforce dependency policy at install time.

```yaml
defaultSemverRangePrefix: ""   # pin: 'yarn add' writes exact versions
```

> **Note:** the 7-day cooldown (`npmMinimalAgeGate`) needs **Yarn ≥ 4.10**; this repo is classic(or<4), so this PR pins only. Cooldown will follow once Yarn is upgraded (tracked separately).

- Cooldown applies to *new/updated* deps; `yarn --immutable` from the committed lockfile is unaffected.
- A follow-up PR will pin existing floating ranges (10 found) and regenerate the lockfile.

Ref: https://fenderdigital.atlassian.net/browse/DENG-215